### PR TITLE
Restore _WIN32 check in jconfig.h

### DIFF
--- a/jconfig.h
+++ b/jconfig.h
@@ -1,4 +1,4 @@
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 #include "jconfig.vc"
 #else
 
@@ -84,4 +84,4 @@ typedef unsigned char boolean;
 
 #endif /* JPEG_CJPEG_DJPEG */
 
-#endif /* _MSC_VER */
+#endif /* _WIN32 */


### PR DESCRIPTION
This was mistakenly changed to _MSC_VER and can cause build errors with MinGW.

See https://github.com/wxWidgets/wxWidgets/issues/26197